### PR TITLE
A catch-all exception handler around the main file processing loop.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 nitpicky = True
 # We need a recent sphinx because of the last update format.
-#needs_sphinx = '1.4'
+# needs_sphinx = '1.4'
 html_last_updated_fmt = 'YYYY-MM-dd'
 templates_path = ['templates']
 

--- a/maildir_deduplicate/deduplicate.py
+++ b/maildir_deduplicate/deduplicate.py
@@ -242,18 +242,18 @@ class Deduplicate(object):
                 if len(message_files) == 1:
                     continue
                 messages = [(mf, read_mailfile(mf)) for mf in message_files]
-    
+
                 subject = messages[0][1].get('Subject', '')
                 subject, count = re.subn('\s+', ' ', subject)
                 logger.info("Subject: {}".format(subject))
-    
+
                 if self.strategy == OLDER:
                     sorted_messages_ctime = self.time_sort(messages, False)
                 elif self.strategy == NEWER:
                     sorted_messages_ctime = self.time_sort(messages, True)
-    
+
                 sorted_messages_size = self.size_sort(messages)
-    
+
                 too_dissimilar = self.messages_too_dissimilar(
                     hash_key, sorted_messages_size)
                 if too_dissimilar == 'size':
@@ -268,10 +268,10 @@ class Deduplicate(object):
                     raise ValueError(
                         "Unexpected value {!r} for too_dissimilar".format(
                             too_dissimilar))
-    
+
                 self.duplicates += len(messages) - 1
                 self.sets += 1
-    
+
                 if self.strategy in [OLDER, NEWER]:
                     self.removed += self.process_duplicate_set(
                         sorted_messages_ctime)


### PR DESCRIPTION
This improves the situation detailed in issue #39 in so far as that exceptions no longer lead to the abortion of the entire processing batch.
Exceptions are output to stderr with stack trace and the filenames being processed, so that the underlying reason and the potentially faulty files can be investigated.

The execution of this is not pretty.
Ideally, exception handlers should be limited to the parts of the code which actually throw exceptions, and exceptions should be handled by name.
This was a quick job to stop the software from needlessly aborting the operation.

The patch was written against the current stable from pip, but applied cleanly to the current development version.
