### PR TITLE
canonical_header_value: convert input strings to unicode

### DIFF
--- a/maildir_deduplicate/mail.py
+++ b/maildir_deduplicate/mail.py
@@ -182,8 +182,8 @@ class Mail(object):
         header = header.lower()
         # Problematic when reading utf8 emails
         # this will ensure value is always string
-        if not type(value) is str:
-            value = value.encode()
+        if isinstance(value, bytes):
+            value = value.decode('utf-8', 'replace')
         value = re.sub(r'\s+', ' ', value).strip()
 
         # Trim Subject prefixes automatically added by mailing list software,


### PR DESCRIPTION
`from __future__ import unicode_literals` causes string literals like `r'\s+'` and `' '` to be unicode, so when an incoming value is a byte string with non-ASCII, or it is a unicode with non-ASCII (which ends up encoded with an unspecified encoding), you get a `UnicodeDecodeError` in `re.sub`.

Instead, decode any byte string; since there's no right choice, but we don't want anything to throw, decode as UTF-8 but use 'replace' so that encoding errors are not fatal.

Closes: #53