### PR TITLE
canonical_header_value: don't fail if mktime_tz does

### DIFF
--- a/maildir_deduplicate/mail.py
+++ b/maildir_deduplicate/mail.py
@@ -78,8 +78,12 @@ class Mail(object):
             return os.path.getctime(self.path)
 
         # Fetch from the date header.
-        return email.utils.mktime_tz(email.utils.parsedate_tz(
-            self.message.get('Date')))
+        value = self.message.get('Date')
+        try:
+            value = email.utils.mktime_tz(email.utils.parsedate_tz(value))
+        except ValueError:
+            pass
+        return value
 
     @cachedproperty
     def size(self):

--- a/maildir_deduplicate/mail.py
+++ b/maildir_deduplicate/mail.py
@@ -221,14 +221,10 @@ class Mail(object):
                 parsed = email.utils.parsedate_tz(value)
                 if not parsed:
                     raise TypeError
-            # If parsedate_tz cannot parse the date.
-            except (TypeError, ValueError):
-                return value
-            utc_timestamp = email.utils.mktime_tz(parsed)
-            try:
+                utc_timestamp = email.utils.mktime_tz(parsed)
                 return time.strftime(
                     '%Y/%m/%d UTC', time.gmtime(utc_timestamp))
-            except ValueError:
+            except (TypeError, ValueError):
                 return value
         elif header == 'to':
             # Sometimes email.parser strips the <> brackets from a To:


### PR DESCRIPTION
At the same time, unify 2 (would now be 3) try/except blocks into a single try/except block

Closes: #54

Signed-off-by: Jeff Epler <jepler@unpythonic.net>