### PR TITLE
Fix click-log API change. Issue #58

### DIFF
--- a/maildir_deduplicate/cli.py
+++ b/maildir_deduplicate/cli.py
@@ -41,22 +41,23 @@ from . import (
     TIME_SOURCES,
     Config,
     __version__,
-    logger
 )
 from .deduplicate import Deduplicate
 from .mail import Mail
 
 
+cli_logger = logging.getLogger(__name__)
+logger = click_log.basic_config('mdedup')
 @click.group(invoke_without_command=True)
-@click_log.init(logger)
 @click_log.simple_verbosity_option(
+    'mdedup',
     default='INFO', metavar='LEVEL',
     help='Either CRITICAL, ERROR, WARNING, INFO or DEBUG. Defaults to INFO.')
 @click.version_option(__version__)
 @click.pass_context
 def cli(ctx):
     """ CLI for maildirs content analysis and deletion. """
-    level = click_log.get_level()
+    level = logging.getLogger('mdedup').level
     try:
         level_to_name = logging._levelToName
     # Fallback to pre-Python 3.4 internals.

--- a/maildir_deduplicate/deduplicate.py
+++ b/maildir_deduplicate/deduplicate.py
@@ -27,6 +27,8 @@ from __future__ import (
 
 import os
 import re
+import logging
+import click_log
 from collections import Counter
 from difflib import unified_diff
 from itertools import combinations
@@ -42,10 +44,11 @@ from . import (
     InsufficientHeadersError,
     MissingMessageID,
     SizeDiffAboveThreshold,
-    logger
 )
 from .mail import Mail
 
+logger = click_log.basic_config('mdedup')
+logger.setLevel(logging.INFO)
 
 class DuplicateSet(object):
 
@@ -205,6 +208,11 @@ class DuplicateSet(object):
             # Call the deduplication strategy.
             self.apply_strategy()
         except UnicodeDecodeError as expt:
+            self.stats['set_rejected_encoding'] += 1
+            logger.warning(
+                "Reject set: unparseable mails due to bad encoding.")
+            logger.debug(str(expt))
+        except UnicodeEncodeError as expt:
             self.stats['set_rejected_encoding'] += 1
             logger.warning(
                 "Reject set: unparseable mails due to bad encoding.")

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ PACKAGE_NAME = MODULE_NAME.replace('_', '-')
 DEPENDENCIES = [
     'boltons >= 16.3.0',
     'click >= 5.0',
-    'click_log',
+    'click_log >= 0.2.0, < 0.3.0',
     'progressbar2',
     'tabulate',
 ]


### PR DESCRIPTION
Fix breaking API change introduced with Click-Log 0.2.0 reported in #58.

Running the script with Python 3.5 required to capture a UnicodeEncodeError exception instead of UnicodeDecodeError.