### PR TITLE
Fix Header being object instead of string, more reliable decoding of body_lines, fix counter statistics, and include Message-ID as canonical_header

### DIFF
--- a/maildir_deduplicate/__init__.py
+++ b/maildir_deduplicate/__init__.py
@@ -61,6 +61,7 @@ HEADERS = [
     'Content-Disposition',
     'User-Agent',
     'X-Priority',
+    'Message-ID',
 ]
 
 

--- a/maildir_deduplicate/deduplicate.py
+++ b/maildir_deduplicate/deduplicate.py
@@ -75,7 +75,6 @@ class DuplicateSet(object):
 
         # Keep set metrics.
         self.stats = Counter()
-        self.stats['mail_duplicates'] += self.size
 
         logger.debug("{!r} created.".format(self))
 
@@ -199,6 +198,7 @@ class DuplicateSet(object):
             self.stats['set_ignored'] += 1
             return
 
+        self.stats['mail_duplicates'] += self.size
         try:
             # Fine-grained checks on mail differences.
             self.check_differences()
@@ -595,7 +595,8 @@ class Deduplicate(object):
         assert self.stats['mail_kept'] == (
             self.stats['mail_unique'] +
             self.stats['mail_duplicates'])
-        assert self.stats['mail_duplicates'] > self.stats['mail_deleted']
+        assert ((self.stats['mail_duplicates'] == 0) or
+                (self.stats['mail_duplicates'] > self.stats['mail_deleted']))
 
         assert self.stats['set_ignored'] == self.stats['mail_unique']
 

--- a/maildir_deduplicate/mail.py
+++ b/maildir_deduplicate/mail.py
@@ -184,6 +184,8 @@ class Mail(object):
         # this will ensure value is always string
         if isinstance(value, bytes):
             value = value.decode('utf-8', 'replace')
+        elif isinstance(value, email.header.Header):
+            value = str(value)
         value = re.sub(r'\s+', ' ', value).strip()
 
         # Trim Subject prefixes automatically added by mailing list software,

--- a/maildir_deduplicate/mail.py
+++ b/maildir_deduplicate/mail.py
@@ -255,7 +255,7 @@ class Mail(object):
                     '%Y/%m/%d UTC', time.gmtime(utc_timestamp))
             except ValueError:
                 return value
-        elif header == 'to':
+        elif header in ['to', 'message-id']:
             # Sometimes email.parser strips the <> brackets from a To:
             # header which has a single address.  I have seen this happen
             # for only one mail in a duplicate pair.  I'm not sure why

--- a/maildir_deduplicate/mail.py
+++ b/maildir_deduplicate/mail.py
@@ -98,20 +98,43 @@ class Mail(object):
     @cachedproperty
     def body_lines(self):
         """ Return a normalized list of lines from message's body. """
-        if not self.message.is_multipart():
-            body = self.message.get_payload(None, decode=True)
-        else:
-            _, _, body = self.message.as_string().partition("\n\n")
-        if isinstance(body, bytes):
-            for enc in ['ascii', 'utf-8']:
-                try:
-                    body = body.decode(enc)
-                    break
-                except UnicodeDecodeError:
-                    continue
+        body = []
+        if self.message.preamble is not None:
+            body.extend(self.message.preamble.splitlines(keepends=True))
+
+        for part in self.message.walk():
+            if part.is_multipart():
+                continue
+
+            ctype = part.get_content_type()
+            cte = part.get_params(header='Content-Transfer-Encoding')
+            if (ctype is not None and not ctype.startswith('text')) or \
+               (cte is not None and cte[0][0].lower() == '8bit'):
+                part_body = part.get_payload(decode=False)
             else:
-                body = self.message.get_payload(None, decode=False)
-        return body.splitlines(True)
+                charset = part.get_content_charset()
+                if charset is None or len(charset) == 0:
+                    charsets = ['ascii', 'utf-8']
+                else:
+                    charsets = [charset]
+
+                part_body = part.get_payload(decode=True)
+                for enc in charsets:
+                    try:
+                        part_body = part_body.decode(enc)
+                        break
+                    except UnicodeDecodeError as ex:
+                        continue
+                    except LookupError as ex:
+                        continue
+                else:
+                    part_body = part.get_payload(decode=False)
+
+            body.extend(part_body.splitlines(keepends=True))
+
+        if self.message.epilogue is not None:
+            body.extend(self.message.epilogue.splitlines(keepends=True))
+        return body
 
     @cachedproperty
     def subject(self):


### PR DESCRIPTION
- Fix Header being object instead of string (#61)

Per [documentation](https://docs.python.org/3/library/email.compat32-message.html): "In a model generated from bytes, any header values that (in contravention of the RFCs) contain non-ASCII bytes will, when retrieved through this interface, be represented as Header objects with a charset of unknown-8bit."

- Make body_lines conversion more reliable

For a multi-part message, `self.message.as_string().partition("\n\n")` can fail without proper decoding. The new implementation should be more reliable.

- Fix bugs in counter statistics (#45, #57)

`self.stats['mail_duplicates'] += duplicates.size` was done only if `len(self.pool) != 1`. In https://github.com/kdeldycke/maildir-deduplicate/commit/0d71f5, this addition was moved to `DuplicateSet.__init__()`, therefore always failing the assertion: `assert self.stats['mail_kept'] == (self.stats['mail_unique'] + self.stats['mail_duplicates'])`.

-  Add Message-ID as a header to check

Even though `Message-ID` can be non-unique or even non-existent and thus cannot be used alone to reliably deduplicate, including it in the canonical header should be harmless. This is especially beneficial at the moment when time is stripped from header `Date`. For example, if there are back-and-forth replies to the same email subject on the same day, the current canonical header will be `Date: YYYY/MM/DD UTC\nFrom: Sender <userA@domainA>\nTo: Recipient <userB@domainB>\nSubject: Re: XYZ...`. `DuplicateSet.check_differences()` will reject the entire set, even when there are duplicates in the set.